### PR TITLE
Move some dependencies to peerDependencies. Bump some dependency versions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+#Webstorm
+/.idea

--- a/Vue2LeafletVectorGridProtobuf.vue
+++ b/Vue2LeafletVectorGridProtobuf.vue
@@ -3,6 +3,20 @@
 <script>
 import L from 'leaflet'
 import 'leaflet.vectorgrid'
+import v2l from 'vue2-leaflet'
+
+if (typeof(L) === "undefined") {
+    throw new Error("leaflet library must be installed in order " +
+                    "to use vue2-leaflet-vectorgrid.")
+}
+if (typeof(L.vectorGrid) === "undefined") {
+    throw new Error("leaflet.vectorgrid library must be installed " +
+                    "in order to use vue2-leaflet-vectorgrid.")
+}
+if (typeof(v2l) === "undefined") {
+    throw new Error("vue2-leaflet Vue Component must be installed " +
+                    "in order to use vue2-leaflet-vectorgrid.")
+}
 
 export default {
   props: {

--- a/package.json
+++ b/package.json
@@ -26,11 +26,13 @@
   },
   "homepage": "https://github.com/tesselo/vue2-leaflet-vectorgrid#readme",
   "dependencies": {
-    "leaflet": "^1.2.0",
-    "leaflet.vectorgrid": "^1.3.0",
-    "vue2-leaflet": "^0.0.55"
+    "leaflet.vectorgrid": "^1.3.0"
   },
   "devDependencies": {
     "poi": "^9.3.10"
+  },
+  "peerDependencies": {
+    "leaflet": "^1.3.1",
+    "vue2-leaflet": "^1.0.1"
   }
 }


### PR DESCRIPTION
Bump vue2-leaflet dependency to ^1.0.1, we want at least this version present.
Bump `leaflet` dependency to ^1.3.1, because that is the same version required by vue2-leaflet
Move leaflet and vue2-leaflet dependencies to peerDependencies, we don't want our own versions of these libs, we should rely on the versions provided by the parent project.
Add runtime (import-time) checking for presence of required peerDependencies.