### PR TITLE
Update depences versions

### DIFF
--- a/Vue2LeafletVectorGridProtobuf.vue
+++ b/Vue2LeafletVectorGridProtobuf.vue
@@ -3,20 +3,6 @@
 <script>
 import L from 'leaflet'
 import 'leaflet.vectorgrid'
-import v2l from 'vue2-leaflet'
-
-if (typeof(L) === "undefined") {
-    throw new Error("leaflet library must be installed in order " +
-                    "to use vue2-leaflet-vectorgrid.")
-}
-if (typeof(L.vectorGrid) === "undefined") {
-    throw new Error("leaflet.vectorgrid library must be installed " +
-                    "in order to use vue2-leaflet-vectorgrid.")
-}
-if (typeof(v2l) === "undefined") {
-    throw new Error("vue2-leaflet Vue Component must be installed " +
-                    "in order to use vue2-leaflet-vectorgrid.")
-}
 
 export default {
   props: {

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "poi": "^9.3.10"
   },
   "peerDependencies": {
-    "leaflet": "^1.3.1",
-    "vue2-leaflet": "^1.0.1",
+    "leaflet": "^1.3.4",
+    "vue2-leaflet": "^2.0.2",
     "leaflet.vectorgrid": "^1.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,14 +25,12 @@
     "url": "https://github.com/tesselo/vue2-leaflet-vectorgrid/issues"
   },
   "homepage": "https://github.com/tesselo/vue2-leaflet-vectorgrid#readme",
-  "dependencies": {
-    "leaflet.vectorgrid": "^1.3.0"
-  },
   "devDependencies": {
     "poi": "^9.3.10"
   },
   "peerDependencies": {
     "leaflet": "^1.3.1",
-    "vue2-leaflet": "^1.0.1"
+    "vue2-leaflet": "^1.0.1",
+    "leaflet.vectorgrid": "^1.3.0"
   }
 }


### PR DESCRIPTION
Moved to peerDependencies:
"leaflet": "^1.3.4",
"vue2-leaflet": "^2.0.2",
"leaflet.vectorgrid": "^1.3.0"

Updated vue2-leaflet to version 2.
Removed checks for `L` and `L.vectorGrid`.
Must fix #6 